### PR TITLE
Add note about the replicaSet value to use in the connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ rs:PRIMARY>
 
 ## Notes on Connecting
 
-The replicaSet setName is `rs`. 
+Use `replicaSet=rs` in your connection string. 
 
 ## Running in Production
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Connecting shell /home/node/lib/node_modules/run-rs/3.6.5/mongo
 rs:PRIMARY>
 ```
 
+## Notes on Connecting
+
+The replicaSet setName is `rs`. 
+
 ## Running in Production
 
 Do **not** use run-rs for running your production database. Run-rs is designed


### PR DESCRIPTION
It was easy enough to find in the mongo shell, but it seems useful to note in the README.