### PR TITLE
Fixes to --mongod and --dbpath options

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -15,7 +15,7 @@ module.exports = Object.freeze([
     description: 'Use this flag to suppress any output after starting'
   },
   {
-    option: '-m, --mongod',
+    option: '-m, --mongod [string]',
     description: 'Skip downloading MongoDB and use this executable. If blank, just uses `mongod`. For instance, `run-rs --mongod` is equivalent to `run-rs --mongod mongod`'
   },
   {


### PR DESCRIPTION
I'm really glad this tool exists, thanks so much for making it!  I was trying to get set up with the latest version today, and I noticed these option-related issues:

1. --mongod not accepting arguments (fixed by adding missing '[script]' in options.js).
2. --mongod arguments not being recognized unless in $CWD (fix by modifying arg validation)
3. --dbpath argument had $CWD added even if it was an absolute path (fix by only adding command.cwd() if --dbpath not supplied).

The fixes were simple enough so I figured I'd submit this PR.

I've only tested this on OS X, but Linux *should* be the same and I tried to keep the functionality consistent for Windows.  Let me know if I should create an issue for this first.

Thanks!