### PR TITLE
fix --help check

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ commander.parse(process.argv);
 co(run).catch(error => console.error(chalk.red(error.stack)));
 
 function* run() {
-  if ('--help' in commander.rawArgs) {
+  if (commander.rawArgs.indexOf('--help') > 0) {
     printHelp();
     return;
   }


### PR DESCRIPTION
the previous line of code simply does not work. `'a' in ['a', 'b']` === false`.

I used indexOf because it appears this is not targeting full ES6.