### PR TITLE
Fix: Replica Set options fixed and error gracefully handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function* run() {
       if (commander.bind_ip_all) {
         options.bind_ip_all = null;
       }
-      return options;
+      return {options: options};
     }), { replSet: 'rs' });
 
   if (commander.keep) {
@@ -208,6 +208,7 @@ function startRS(rs) {
     try {
       yield rs.start();
     } catch (err) {
+      err = err[0];
       if (err.message.includes('SocketException: Address already in use')) {
         const match = err.message.match(/port: (\d+)/);
         if (match != null) {


### PR DESCRIPTION
Hey,

I am requesting you to merge this PR. This addresses 2 issues:

1. options was not passed from the index file correctly into the **ReplSet** constructor. It needed to be an object with options key having a nested json with the actual options. I've addressed the same.

2. The startRS catch block had an error in itself. If err didn't contain message field, we were still doing err.message.includes, which was breaking saying _**TypeError: Cannot read property 'includes' of undefined**_ . I've added graceful handling of the same.

Please review.
Thanks,
Ayush Jain
![2](https://user-images.githubusercontent.com/67269493/95194257-ae23e480-07f2-11eb-83af-468d3d1b79eb.png)
