### PR TITLE
Use https to download mongodb

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -16,7 +16,7 @@ module.exports = function download(version, systemLinux, os) {
   os = os || process.platform;
   let dirname;
   let filename;
-  let base = 'http://downloads.mongodb.org';
+  let base = 'https://downloads.mongodb.org';
 
   const mainScriptDir = path.resolve(__dirname, '..');
   const isBefore42 = major < 4 || (major === 4 && minor < 2);


### PR DESCRIPTION
Currently we have to do a workaround to use run-rs in our CI/CD Pipeline as our company proxy only allows https connections.