### PR TITLE
Use node `fs` module instead of `execSync` where possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const moment = require('moment');
 const mongodb = require('mongodb');
 const options = require('./src/options');
+const path = require('path');
 const prettyjson = require('prettyjson');
 const printHelp = require('./src/printHelp');
 const spawn = require('child_process').spawn;
@@ -38,7 +39,7 @@ function* run() {
   }
 
   const options = {};
-  const rcfile = isWin ? `${process.cwd()}\\.run-rs.rc` : `${process.cwd()}/.run-rs.rc`;
+  const rcfile = path.join(process.cwd(), '.run-rs.rc');
   if (fs.existsSync(rcfile)) {
     Object.assign(options, JSON.parse(fs.readFileSync(rcfile, 'utf8')));
   }
@@ -89,23 +90,23 @@ function* run() {
     dbPath = `${commander.dbpath}` ;
   }
   else {
-    dbPath = isWin ? `${process.cwd()}\\data` : `${process.cwd()}/data`;
+    dbPath = path.join(process.cwd(), 'data');
   }
 
   if (!fs.existsSync(`${dbPath}`)) {
-    execSync(isWin ? `md ${dbPath}` : `mkdir -p ${dbPath}`);
+    fs.mkdirSync(dbPath, { recursive: true });
   }
   if (commander.keep) {
     console.log(chalk.blue('Skipping purge'));
   } else {
     console.log(chalk.blue('Purging database...'));
-    execSync(isWin ? `del /S /Q ${dbPath}\\*` : `rm -rf ${dbPath}/*`);
+    fs.rmSync(path.join(dbPath, '*'), { force: true, recursive: true })
   }
 
   ports.forEach((port) => {
-    const portDBPath = isWin ? `${dbPath}\\${port}` : `${dbPath}/${port}`;
+    const portDBPath = path.join(dbPath, port.toString());;
     if (!fs.existsSync(portDBPath)) {
-      execSync(isWin ? `md ${dbPath}\\${port}` : `mkdir -p ${dbPath}/${port}`);
+      fs.mkdirSync(portDBPath);
     }
   });
 
@@ -113,8 +114,8 @@ function* run() {
   const rs = new ReplSet(mongod,
     ports.map(port => {
       const options = {
-        port: port,
-        dbpath: isWin ? `${dbPath}\\${port}` : `${dbPath}/${port}`,
+        port,
+        dbpath: path.join(dbPath, port.toString()),
         bind_ip: hostname
       };
       if (commander.bind_ip_all) {

--- a/index.js
+++ b/index.js
@@ -100,7 +100,15 @@ function* run() {
     console.log(chalk.blue('Skipping purge'));
   } else {
     console.log(chalk.blue('Purging database...'));
-    fs.rmSync(path.join(dbPath, '*'), { force: true, recursive: true })
+    const dir = fs.opendirSync(dbPath);
+
+    let file;
+    while (file = dir.readSync()) {
+      fs.rmSync(path.join(dbPath, file.name), {
+        force: true,
+        recursive: true
+      });
+    }
   }
 
   ports.forEach((port) => {

--- a/src/download.js
+++ b/src/download.js
@@ -63,23 +63,25 @@ module.exports = function download(version, systemLinux, os) {
       throw new Error(`Unrecognized os ${os}`);
   }
 
-  const url = path.join(base, os, filename);
+  const url = `${base}/${os}/${filename}`;
 
   if (os.startsWith('win')) {
     execSync('powershell.exe -nologo -noprofile -command "&{' +
       'Add-Type -AssemblyName System.IO.Compression.FileSystem;' +
       `(New-Object Net.WebClient).DownloadFile('${url}', '${filename}');` +
       `[System.IO.Compression.ZipFile]::ExtractToDirectory('${filename}', '.');` +
-      '}"'
-    );
+    '}"');
   } else {
     execSync(`curl -OL ${url}`);
     execSync(`tar -zxvf ${filename}`);
   }
 
+  const targetDir = path.join(mainScriptDir, version);
+
+  fs.rmSync(targetDir, { force: true, recursive: true })
   fs.renameSync(
     path.join(process.cwd(), dirname, 'bin'),
-    path.join(mainScriptDir, version)
+    targetDir
   );
   fs.rmSync(path.join(process.cwd(), dirname), { force: true, recursive: true });
   fs.rmSync(path.join(process.cwd(), filename));

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -17,10 +17,10 @@ describe('download', function() {
 
   it('basic download', function() {
     let { url } = download('4.0.6', 'ubuntu1604', 'linux');
-    assert.equal(url, 'http://downloads.mongodb.org/linux/mongodb-linux-x86_64-4.0.6.tgz');
+    assert.equal(url, 'https://downloads.mongodb.org/linux/mongodb-linux-x86_64-4.0.6.tgz');
 
     ({ url } = download('4.2.0', 'ubuntu1604', 'linux'));
-    assert.equal(url, 'http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.0.tgz');
+    assert.equal(url, 'https://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.0.tgz');
   });
 
   it('osx 4.2.0', function() {
@@ -30,6 +30,6 @@ describe('download', function() {
 
   it('osx < 4.2.0', function() {
     let { url } = download('4.0.6', null, 'darwin');
-    assert.equal(url, 'http://downloads.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.6.tgz');
+    assert.equal(url, 'https://downloads.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.6.tgz');
   });
 });


### PR DESCRIPTION
These were the instances of `execSync` of some system command I found to be pretty easily replaceable with Node's `fs` module methods. Tests seemed to run fine with the `execSync` stub commented out, had to make a couple changes (`http` => `https`) to get them working but that seemed to be fixing an existing issue with the tests. It eliminated a lot of `isWin` ternaries, which is nice.

The reason I started in on this was that I had an issue running plain `run-rs` on Windows 10, which produced the following error:
```
Error: Command failed: del /S /Q C:\\Users\\lmooo\\AppData\\Roaming\\KnudgeDevelopment\\database\*
The specified path is not valid. 

    at checkExecSyncError (node:child_process:707:11)
    at execSync (node:child_process:744:15)
    at run (C:\Users\lmooo\Documents\GitHub\[...]\node_modules\run-rs\index.js:102:5)
    at run.next (<anonymous>)
    at onFulfilled (C:\Users\lmooo\Documents\GitHub\[...]\node_modules\co\index.js:65:19)
    at C:\Users\lmooo\Documents\GitHub\[...]\node_modules\co\index.js:54:5
    at new Promise (<anonymous>)
    at co (C:\Users\lmooo\Documents\GitHub\[...]\node_modules\co\index.js:50:10)
    at Object.<anonymous> (C:\Users\lmooo\Documents\GitHub\[...]\node_modules\run-rs\index.js:32:1)
    at Module._compile (node:internal/modules/cjs/loader:1092:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
    at Module.load (node:internal/modules/cjs/loader:972:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
    at node:internal/main/run_main_module:17:47
```

I tested these changes on Windows 10 (21H1, latest updates) and macOS (Mojave, latest updates).